### PR TITLE
Add pyarrow shim

### DIFF
--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -1,5 +1,5 @@
 from hashlib import md5
-from .utils import read_block
+from .utils import read_block, get_pyarrow_filesystem
 
 aliases = [
     ('makedir', 'mkdir'),
@@ -512,6 +512,12 @@ class AbstractFileSystem(object):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+
+    def _get_pyarrow_filesystem(self):
+        """
+        Make a version of the FS instance which will be acceptable to pyarrow
+        """
+        return get_pyarrow_filesystem(self)
 
 
 class Transaction(object):

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -519,6 +519,15 @@ class AbstractFileSystem(object):
         """
         return get_pyarrow_filesystem(self)
 
+    def get_mapper(self, root, check=False, create=False):
+        """Create key/value store based on this file-system
+
+        Makes a MutibleMapping interface to the FS at the given root path.
+        See ``fsspec.mapping.FSMap`` for further details.
+        """
+        from .mapping import FSMap
+        return FSMap(root, self, check, create)
+
 
 class Transaction(object):
     """Filesystem transaction context

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -109,6 +109,11 @@ def tokenize(*args, **kwargs):
 
 
 def get_pyarrow_filesystem(fs):
+    """Make a version of the FS instance which will be acceptable to pyarrow
+
+    This just copies everything, but adds the pyarrow FileSystem as a
+    superclass, so that in arrow functions it passes isinstance checks.
+    """
     import pyarrow as pa
 
     class PyarrowWrappedFS(fs.__class__, pa.filesystem.DaskFileSystem):

--- a/fsspec/utils.py
+++ b/fsspec/utils.py
@@ -106,3 +106,16 @@ def tokenize(*args, **kwargs):
     if kwargs:
         args += (kwargs,)
     return md5(str(args).encode()).hexdigest()
+
+
+def get_pyarrow_filesystem(fs):
+    import pyarrow as pa
+
+    class PyarrowWrappedFS(fs.__class__, pa.filesystem.DaskFileSystem):
+
+        def __init__(self, fs):
+            self.fs = fs
+            self.name = str(fs.__class__)
+            self.__dict__.update(fs.__dict__)
+
+    return PyarrowWrappedFS(fs)


### PR DESCRIPTION
Allows to make a pyarrow-compatible version of any file-system meeting
the spec, e.g., for use with pyarrow.parquet.ParquetDataset