### PR TITLE
Fixes: missing protocol attr, isfile, isdir 

### DIFF
--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -184,6 +184,23 @@ def test_not_found():
             pass
 
 
+def test_isfile():
+    fs = LocalFileSystem()
+    with filetexts(files, mode='b'):
+        for f in files.keys():
+            assert fs.isfile(f)
+        assert not fs.isfile('not-a-file')
+
+
+def test_isdir():
+    fs = LocalFileSystem()
+    with filetexts(files, mode='b'):
+        for f in files.keys():
+            assert fs.isdir(os.path.dirname(os.path.abspath(f)))
+            assert not fs.isdir(f)
+        assert not fs.isdir('not-a-dir')
+
+
 @pytest.mark.parametrize('compression_opener',
                          [(None, open), ('gzip', gzip.open)])
 def test_open_files_write(tmpdir, compression_opener):

--- a/fsspec/registry.py
+++ b/fsspec/registry.py
@@ -59,7 +59,7 @@ def get_filesystem_class(protocol):
             raise RuntimeError(str(err))
         registry[protocol] = getattr(mod, name)
     cls = registry[protocol]
-    if cls.protocol == 'abstract' or cls.protocol is None:
+    if getattr(cls, 'protocol', None) in ('abstract', None):
         cls.protocol = protocol
 
     return cls

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -405,11 +405,17 @@ class AbstractFileSystem(object):
 
     def isdir(self, path):
         """Is this entry directory-like?"""
-        return self.info(path)['type'] == 'directory'
+        try:
+            return self.info(path)['type'] == 'directory'
+        except FileNotFoundError:
+            return False
 
     def isfile(self, path):
         """Is this entry file-like?"""
-        return self.info(path)['type'] == 'file'
+        try:
+            return self.info(path)['type'] == 'file'
+        except FileNotFoundError:
+            return False
 
     def cat(self, path):
         """ Get the content of a file """


### PR DESCRIPTION
Two fixes:
- External filesystem classes may not have a `protocol` attribute (e.g. `S3FileSystem`)
- isfile and isdir should not raise `FileNotFoundError` is the path doesn't exist