### PR TITLE
fix kerberos auth

### DIFF
--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -85,12 +85,10 @@ class WebHDFS(AbstractFileSystem):
         self._connect()
 
     def _connect(self):
+        self.session = requests.Session()
         if self.kerb:
             from requests_kerberos import HTTPKerberosAuth
-            self.session = requests.Session(
-                auth=HTTPKerberosAuth(**self.kerb_kwargs))
-        else:
-            self.session = requests.Session()
+            self.session.auth = HTTPKerberosAuth(**self.kerb_kwargs)
 
     def _call(self, op, method='get', path=None, data=None,
               redirect=True, **kwargs):


### PR DESCRIPTION
I was able to get the following code to work from a Kerberized EMR cluster.

```python
from fsspec.implementations.webhdfs import WebHDFS

webhdfs = WebHDFS('ip-172-31-56-231.ec2.internal', kerberos=True)
files = webhdfs.ls('/user/instructor')
print(files)

data = webhdfs.cat('/user/instructor/autompg.csv')
print(data[:1024])
```