### PR TITLE
Suggested fixes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,11 +8,13 @@ User Functions
 
 .. autosummary::
    fsspec.open_files
+   fsspec.open
    fsspec.filesystem
    fsspec.get_filesystem_class
    fsspec.get_mapper
 
 .. autofunction:: fsspec.open_files
+.. autofunction:: fsspec.open
 .. autofunction:: fsspec.filesystem
 .. autofunction:: fsspec.get_filesystem_class
 .. autofunction:: fsspec.get_mapper

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -72,10 +72,10 @@ or write mode (create names). Critically, the file on the backend system is not 
 
 .. code-block:: python
 
-   files = fsspec.open_files('https://raw.githubusercontent.com/dask/'
-                             'fastparquet/master/test-data/nation.csv', mode='r')
-   # files is a list of not-yet-open objects
-   with files[0] as f:
+   of = fsspec.open('https://raw.githubusercontent.com/dask/'
+                    'fastparquet/master/test-data/nation.csv', mode='r')
+   # files is a not-yet-open OpenFile object. The "with" context actually opens it
+   with of as f:
        # now f is a text-mode file
        df = pd.read_csv(f, sep='|', header=None)
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -53,7 +53,7 @@ to work with python files. These will normally be binary-mode only, but may impl
 in order to limit the number of reads from a remote source. They respect the use of ``with`` contexts. If
 you have ``pandas`` installed, for example, you can do the following:
 
-.. code-block::
+.. code-block:: python
 
     with fs.open('https://raw.githubusercontent.com/dask/'
                  'fastparquet/master/test-data/nation.csv') as f:

--- a/fsspec/__init__.py
+++ b/fsspec/__init__.py
@@ -17,5 +17,5 @@ except ImportError:
 
 from .registry import get_filesystem_class, registry, filesystem
 from .mapping import FSMap, get_mapper
-from .core import open_files, get_fs_token_paths
+from .core import open_files, get_fs_token_paths, open
 

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -88,6 +88,11 @@ def open_files(urlpath, mode='rb', compression=None, encoding='utf8',
                errors=None, name_function=None, num=1, protocol=None, **kwargs):
     """ Given a path or paths, return a list of ``OpenFile`` objects.
 
+    For writing, a str path must contain the "*" character, which will be filled
+    in by increasing numbers, e.g., "part*" ->  "part1", "part2" if num=2.
+
+    For either reading or writing, can instead provide explicit list of paths.
+
     Parameters
     ----------
     urlpath : string or list
@@ -282,8 +287,7 @@ def get_fs_token_paths(urlpath, mode='rb', num=1, name_function=None,
 def _expand_paths(path, name_function, num):
     if isinstance(path, str):
         if path.count('*') != 1:
-            raise ValueError("Output path spec must contain exactly most one "
-                             "'*'.")
+            raise ValueError("Output path spec must contain exactly one '*'.")
 
         if name_function is None:
             name_function = build_name_function(num - 1)

--- a/fsspec/implementations/local.py
+++ b/fsspec/implementations/local.py
@@ -102,6 +102,10 @@ class LocalFileOpener(object):
             raise RuntimeError('Cannot discard if set to autocommit')
         os.remove(self.temp)
 
+    def __fspath__(self):
+        # uniquely for fsspec implementations, this is a real path
+        return self.path
+
     def __getattr__(self, item):
         return getattr(self.f, item)
 

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -205,8 +205,8 @@ def test_isdir():
                          [(None, open), ('gzip', gzip.open)])
 def test_open_files_write(tmpdir, compression_opener):
     compression, opener = compression_opener
-    tmpdir = str(tmpdir) + "/*"
-    files = open_files(tmpdir, num=2, mode='wb', compression=compression)
+    fn = str(tmpdir) + "/*.part"
+    files = open_files(fn, num=2, mode='wb', compression=compression)
     assert len(files) == 2
     assert {f.mode for f in files} == {'wb'}
     for fil in files:

--- a/fsspec/implementations/tests/test_local.py
+++ b/fsspec/implementations/tests/test_local.py
@@ -205,7 +205,7 @@ def test_isdir():
                          [(None, open), ('gzip', gzip.open)])
 def test_open_files_write(tmpdir, compression_opener):
     compression, opener = compression_opener
-    tmpdir = str(tmpdir)
+    tmpdir = str(tmpdir) + "/*"
     files = open_files(tmpdir, num=2, mode='wb', compression=compression)
     assert len(files) == 2
     assert {f.mode for f in files} == {'wb'}


### PR DESCRIPTION
Fixes #31 
Fixes #32 

Enables:
```
import h5py
import fsspec

with fsspec.open('test.h5', 'wb') as f:
  with h5py.File(f, 'w') as h5file:
    h5file.attrs['foo'] = 'bar'
```

and
```
import scipy.io
import fsspec

with fsspec.open('test2.nc', 'wb') as f:
  with scipy.io.netcdf_file(f, 'w') as nc:
    nc.foo = 'bar'
```

Not sure how to add tests here, as depends on extra external packages.