### PR TITLE
Add experimental FUSE support

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,12 +12,14 @@ User Functions
    fsspec.filesystem
    fsspec.get_filesystem_class
    fsspec.get_mapper
+   fsspec.fuse.run
 
 .. autofunction:: fsspec.open_files
 .. autofunction:: fsspec.open
 .. autofunction:: fsspec.filesystem
 .. autofunction:: fsspec.get_filesystem_class
 .. autofunction:: fsspec.get_mapper
+.. autofunction:: fsspec.fuse.run
 
 Base Classes
 ------------
@@ -43,6 +45,9 @@ Base Classes
 
 .. autoclass:: fsspec.core.OpenFile
    :members:
+
+
+.. _implementations:
 
 Built-in Implementations
 ------------------------

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -1,0 +1,167 @@
+Features of fsspec
+==================
+
+Consistent API to many different storage backends. The general API and functionality were
+proven with the projects `s3fs`_ and `gcsfs`_ (along with `hdfs3`_ and `adlfs`_), within the
+context of Dask and independently. These have been tried and tested by many users and shown their
+usefulness over some years. ``fsspec`` aims to build on these and unify their models, as well
+as extract out file-system handling code from Dask which does not so comfortably fit within a
+library designed for task-graph creation and their scheduling.
+
+.. _s3fs: https://s3fs.readthedocs.io/en/latest/
+.. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
+.. _hdfs3: https://hdfs3.readthedocs.io/en/latest/
+.. _adlfs: https://azure-datalake-store.readthedocs.io/en/latest/
+
+Here follows a brief description of some features of note of ``fsspec`` that promide to make
+it an interesting project beyond some other file-system abstractions
+
+Serialisability
+---------------
+
+Coming out of the Dask stable, it was an important design decision that file-system instances
+be serialisable, so that they could be created in one process (e.g., the client) and used in
+other processes (typically the workers). These other processes may even be on other machines,
+so in many cases they would need to be able to re-establish credentials, ideally without passing
+sensitive tokens in the pickled binary data.
+
+``fsspec`` instances, generally speaking, abide by these rules, do not include locks, files and other
+thread-local material, and where possible, use local credentials (such as a token file)
+for re-establishing sessions upon de-serialisation. (While making use of cached instances, where
+they exist, see below).
+
+``OpenFile`` instances
+----------------------
+
+The :func:`fsspec.core.OpenFile` class provides a convenient way to prescribe the manner to
+open some file (local,
+remote, in a compressed store, etc.) which is portable, and ca also apply any compression and
+text-mode to the file. These instances are also serialisable, because the do not contain any open
+files.
+
+The way to work with ``OpenFile`` s is to isolate interaction with in a ``with`` context. It is
+the initiation of the context which actually does the work of creating file-like instances.
+
+.. code-block:: python
+
+    of = fsspec.open(url, ...)
+    # of is just a place-holder
+    with of as f:
+        # f is now a real file-like object holding resources
+        f.read(...)
+
+Random Access and Buffering
+---------------------------
+
+The :func:`fsspec.spec.AbstractBufferedFile` class is provided as an easy way to build file-like
+interfaces to some service which is capable of providing blocks of bytes. This class is derived
+from in a number of the existing implementations. A subclass of ``AbstractBufferedFile`` provides
+random access for the underlying file-like data (without downloading the whole thing) and
+configurable read-ahead buffers to minimise the number of the read operations that need to be
+performed on the back-end storage.
+
+This is also a critical feature in the big-data access model, where each sub-task of an operation
+may need on a small part of a file, and does not, therefore want to be forces into downloading the
+whole thing.
+
+Transparent text-mode and compression
+-------------------------------------
+
+As mentioned above, the ``OpenFile`` class allows for the opening of files on a binary store,
+which appear to be in text mode and/or allow for a compression/decompression layer between the
+caller and the back-end storage system. From the user's point of view, this is achieved simply
+by passing arguments to the :func:`fsspec.open_files` or :func:`fsspec.open` functions, and
+thereafter happens transparently.
+
+Key-value stores
+----------------
+
+File-systems are naturally like dict-like key-value mappings: each (string) path corresponds to some
+binary data on the storage back-end. For some use-cases, it is very convenient to be able to
+view some path within the file-system as a dict-like store, and the function :func:`fsspec.get_mapper`
+gives a one-stop way to return such an object. This has become useful, for example, in the
+context of the `zarr`_ project, which stores it array chunks in keys in any arbitrary mapping-like
+object.
+
+.. code-block:: python
+
+    mapper = fsspec.get_mapper('protocol://server/path', args)
+    list(mapper)
+    mapper[k] = b'some data'
+
+.. _zarr: https://zarr.readthedocs.io/en/stable/
+
+PyArrow integration
+-------------------
+
+`pyarrow`_ has its own internal idea of what a file-system is (``pyarrow.filesystem.FileSystem``),
+and some functions, particularly the loading of parquet, require that the target be compatible.
+As it happens, the design of the file-system interface in ``pyarrow`` *is* compatible with `fsspec`
+(this is not by accident). Therefore at import time, ``fsspec`` checks for the existence of
+``pyarrow``, and, if found, adds it to the superclasses of the spec base-class. In this manner,
+all ``fsspec``-derived file-systems are also pyarrow file-systems, and can be used by pyarrow
+functions.
+
+.. _pyarrow: https://arrow.apache.org/docs/python/
+
+Transactions
+------------
+
+``fsspec`` supports *transactions*, during which writing to files on a remote store are deferred
+(typically put into a temporary location) until the transaction is over, whereupon the whole
+transaction is finalised in a semi-atomic way, and all the files are moved/committed to their
+final destination. The implementation of the details is file-system specific (and not all
+support it yet), but the idea is,
+that all files should get written or none, to mitigate against data corruption. The feature
+can be used like
+
+.. code-block:: python
+
+    fs = fsspec.filesystem(...)
+    with fs.transation:
+        with fs.open('file1', 'wb') as f:
+            f.write(b'some data')
+        with fs.open('file2', 'wb') as f:
+            f.write(b'more data')
+
+Here, files 1 and 2 do not get moved to the target location until the transaction context finishes.
+If the context finishes due to an (uncaught) exception, then the files are discarded and the
+file target locations untouched.
+
+The class :func:`fsspec.spec.Transaction` allows for fine-tuning of the operation, and every
+``fsspec`` instance has an instance of this as an attribute ``.transaction`` to give access.
+
+Note that synchronising transactions across multiple instances, perhaps across a cluster,
+is a harder problem to solve, and the implementation described here is only part of the solution.
+
+Mount anything with FUSE
+------------------------
+
+Any path of any file-system can be mapped to a local directory using pyfuse and
+:func:`sspec.fuse.run`. This feature is experimental, but basic file listing with
+details, and read/write should generally be available to the extent that the
+remote file-system provides enough information. Naturally, if a file-system is read-only,
+then write operations will fail - but they will tend to fail late and with obscure
+error messages such as "bad address".
+
+Some specific quirks of some file-systems may cause confusion for FUSE. For example,
+it is possible for a given path on s3 to be both a valid key (i.e., containing binary
+data, like a file) and a valid prefix (i.e., can be listed to find subkeys, like a
+directory). Since this breaks the assumptions of a normal file-system, it may not
+be possible to reach all paths on the remote.
+
+Instance Caching
+----------------
+
+In a file-system implementation class is marked as *cachable* (attribute ``.cachable``),
+then its instances will
+get stored in a class attribute, to enable quick look-up instead of needing to regenerate
+potentially expensive connections and sessions. They key in the cache is a tokenisation of
+the arguments to create the instance. The cache itself (attribute ``._cache``)
+is currently a simple dict, but could in the future be LRU, or something more complicated,
+to fine-tune instance lifetimes.
+
+Since files can hold on to write caches and read buffers,
+the instance cache may cause excessive memory usage in some situations; but normally, files
+will get ``close``d, and the data discarded. Only when there is also an unfinalised transaction or
+captured traceback might this be anticipated becoming a problem.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,10 @@ Highlights
   can work with any arrow function expecting such an instance
 - writes can be transactional: stored in a temporary location and only moved to the final
   destination when the transaction is committed
+- FUSE: mount any path from any backend to a point on your file-system
+- cached instances tokenised on the instance parameters
 
+These are described further in the :doc:`features` section.
 
 Installation
 ------------
@@ -32,6 +35,13 @@ or
 
    conda install -c conda-forge fsspec
 
+Implementations
+---------------
+
+This repo contains several file-system implementations, see :ref:`implementations`. However,
+the external projects ``s3fs`` and ``gcsfs`` are also developing compatibility with ``fsspec`` and
+will eventually depend upon it.
+
 
 .. toctree::
    :maxdepth: 2
@@ -39,6 +49,7 @@ or
 
    intro.rst
    usage.rst
+   features.rst
    api.rst
 
 

--- a/fsspec/core.py
+++ b/fsspec/core.py
@@ -165,6 +165,8 @@ def open(urlpath, mode='rb', compression=None, encoding='utf8',
     --------
     >>> openfile = open('2015-01-01.csv')  # doctest: +SKIP
     >>> openfile = open('s3://bucket/2015-01-01.csv.gz', compression='gzip')  # doctest: +SKIP
+    ... with openfile as f:
+    ...     df = pd.read_csv(f)
 
     Returns
     -------

--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -22,7 +22,7 @@ class FUSEr(Operations):
         self.counter = 0
     
     def getattr(self, path, fh=None):
-        path = ''.join([self.root, path.lstrip('/')])
+        path = ''.join([self.root, path.lstrip('/')]).rstrip('/')
         info = self.fs.info(path)
         data = {'st_uid': 1000, 'st_gid': 1000}
         perm = 0o777

--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -118,6 +118,34 @@ class FUSEr(Operations):
 
 
 def run(fs, path, mount_point, foreground=True, threads=False):
-    """ Mount stuff in local directory """
+    """ Mount stuff in a local directory
+
+    This uses pyfuse to make it appear as if a given path on an fsspec
+    instance is in fact resident within the local file-system.
+
+    This requires that pyfuse by installed, and that FUSE be available on
+    the system (typically requiring a package to be installed with
+    apt, yum, brew, etc.).
+
+    Parameters
+    ----------
+    fs : file-system instance
+        From one of the compatible implementations
+    path : str
+        Location on that file-system to regard as the root directory to
+        mount. Note that you typically should include the terminating "/"
+        character.
+    mount_point : str
+        An empty directory on the local file-system where the contents of
+        the remote path will appear
+    foreground : bool
+        Whether or not calling this function will block. Operation will
+        typically be more stable if True.
+    threads : bool
+        Whether or not to create threads when responding to file operations
+        within the mounter directory. Operation will typically be more
+        stable if False.
+
+    """
     FUSE(FUSEr(fs, path),
          mount_point, nothreads=not threads, foreground=foreground)

--- a/fsspec/fuse.py
+++ b/fsspec/fuse.py
@@ -1,0 +1,123 @@
+from __future__ import print_function
+import os
+import stat
+from errno import ENOENT, EIO
+from fuse import Operations, FuseOSError
+import time
+import pandas as pd
+from fuse import FUSE
+
+
+def str_to_time(s):
+    t = pd.to_datetime(s)
+    return t.to_datetime64().view('int64') / 1e9
+
+
+class FUSEr(Operations):
+
+    def __init__(self, fs, path):
+        self.fs = fs
+        self.cache = {}
+        self.root = path
+        self.counter = 0
+    
+    def getattr(self, path, fh=None):
+        path = ''.join([self.root, path.lstrip('/')])
+        info = self.fs.info(path)
+        data = {'st_uid': 1000, 'st_gid': 1000}
+        perm = 0o777
+
+        if info['type'] != 'file':
+            data['st_mode'] = (stat.S_IFDIR | perm)
+            data['st_size'] = 0
+            data['st_blksize'] = 0
+        else:
+            data['st_mode'] = (stat.S_IFREG | perm)
+            data['st_size'] = info['size']
+            data['st_blksize'] = 5 * 2**20
+            data['st_nlink'] = 1
+        data['st_atime'] = time.time()
+        data['st_ctime'] = time.time()
+        data['st_mtime'] = time.time()
+        return data
+
+    def readdir(self, path, fh):
+        path = ''.join([self.root, path.lstrip('/')])
+        files = self.fs.ls(path, False)
+        files = [os.path.basename(f.rstrip('/')) for f in files]
+        return ['.', '..'] + files
+    
+    def mkdir(self, path, mode):
+        path = ''.join([self.root, path.lstrip('/')])
+        self.fs.mkdir(path)
+        return 0
+    
+    def rmdir(self, path):
+        path = ''.join([self.root, path.lstrip('/')])
+        self.fs.rmdir(path)
+        return 0
+    
+    def read(self, path, size, offset, fh):
+        f = self.cache[fh]
+        f.seek(offset)
+        out = f.read(size)
+        return out
+    
+    def write(self, path, data, offset, fh):
+        f = self.cache[fh]
+        f.write(data)
+        return len(data)
+    
+    def create(self, path, flags, fi=None):
+        if fi is not None:
+            print(fi)
+        fn = ''.join([self.root, path.lstrip('/')])
+        f = self.fs.open(fn, 'wb')
+        self.cache[self.counter] = f
+        self.counter += 1
+        return self.counter - 1
+    
+    def open(self, path, flags):
+        fn = ''.join([self.root, path.lstrip('/')])
+        if flags % 2 == 0:
+            # read
+            mode = 'rb'
+        else:
+            # write/create
+            mode = 'wb'
+        self.cache[self.counter] = self.fs.open(fn, mode)
+        self.counter += 1
+        return self.counter - 1
+
+    def truncate(self, path, length, fh=None):
+        fn = ''.join([self.root, path.lstrip('/')])
+        if length != 0:
+            raise NotImplementedError
+        # maybe should be no-op since open with write sets size to zero anyway
+        self.fs.touch(fn)
+    
+    def unlink(self, path):
+        fn = ''.join([self.root, path.lstrip('/')])
+        try:
+            self.fs.rm(fn, False)
+        except (IOError, FileNotFoundError):
+            raise FuseOSError(EIO)
+    
+    def release(self, path, fh):
+        try:
+            if fh in self.cache:
+                f = self.cache[fh]
+                f.close()
+                self.cache.pop(fh)
+        except Exception as e:
+            print(e)
+        return 0
+    
+    def chmod(self, path, mode):
+        raise NotImplementedError
+
+
+def run(fs, path, mount_point, foreground=True, threads=False):
+    """ Mount stuff in local directory """
+    FUSE(FUSEr(fs, path),
+         mount_point, nothreads=not threads, foreground=foreground)

--- a/fsspec/implementations/ftp.py
+++ b/fsspec/implementations/ftp.py
@@ -48,6 +48,15 @@ class FTPFileSystem(AbstractFileSystem):
         self.ftp.connect(self.host, self.port)
         self.ftp.login(*self.cred)
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('ftp')
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._connect()
+
     @classmethod
     def _strip_protocol(cls, path):
         return '/' + infer_storage_options(path)['path'].lstrip('/').rstrip('/')

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -59,7 +59,7 @@ class SFTPFileSystem(AbstractFileSystem):
     def mkdir(self, path, mode=511):
         self.ftp.mkdir(path, mode)
 
-    def mkdirs(self, path, mode=511):
+    def makedirs(self, path, mode=511):
         parts = path.split('/')
         path = ''
         for part in parts:

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -35,7 +35,7 @@ class SFTPFileSystem(AbstractFileSystem):
     def _connect(self):
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.client.connect(self.host, **self.ssh_kwargs)
+        self.client.connect(self.host, **self.kwargs)
         self.ftp = self.client.open_sftp()
 
     def __getstate__(self):

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -27,11 +27,26 @@ class SFTPFileSystem(AbstractFileSystem):
             May include port, username, password...
         """
         super(SFTPFileSystem, self).__init__(**ssh_kwargs)
+        self.temppath = ssh_kwargs.get('temppath', '/tmp')
+        self.host = host
+        self.kwargs = ssh_kwargs
+        self._connect()
+
+    def _connect(self):
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.client.connect(host, **ssh_kwargs)
+        self.client.connect(self.host, **self.ssh_kwargs)
         self.ftp = self.client.open_sftp()
-        self.temppath = ssh_kwargs.get('temppath', '/tmp')
+
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('ftp', None)
+        d.pop('client', None)
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._connect()
 
     @classmethod
     def _strip_protocol(cls, path):

--- a/fsspec/implementations/sftp.py
+++ b/fsspec/implementations/sftp.py
@@ -29,13 +29,13 @@ class SFTPFileSystem(AbstractFileSystem):
         super(SFTPFileSystem, self).__init__(**ssh_kwargs)
         self.temppath = ssh_kwargs.get('temppath', '/tmp')
         self.host = host
-        self.kwargs = ssh_kwargs
+        self.ssh_kwargs = ssh_kwargs
         self._connect()
 
     def _connect(self):
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.client.connect(self.host, **self.kwargs)
+        self.client.connect(self.host, **self.ssh_kwargs)
         self.ftp = self.client.open_sftp()
 
     def __getstate__(self):

--- a/fsspec/implementations/webhdfs.py
+++ b/fsspec/implementations/webhdfs.py
@@ -90,6 +90,15 @@ class WebHDFS(AbstractFileSystem):
             from requests_kerberos import HTTPKerberosAuth
             self.session.auth = HTTPKerberosAuth(**self.kerb_kwargs)
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop('session', None)
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._connect()
+
     def _call(self, op, method='get', path=None, data=None,
               redirect=True, **kwargs):
         url = self.url + quote(path or "")

--- a/fsspec/implementations/zip.py
+++ b/fsspec/implementations/zip.py
@@ -84,10 +84,6 @@ class ZipFileSystem(AbstractFileSystem):
         else:
             return list(sorted(f['name'] for f in out))
 
-    def info(self, path):
-        self._get_dirs()
-        return self.dir_cache[path]
-
     def cat(self, path):
         return self.zip.read(path)
 

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -3,8 +3,10 @@ import io
 from .utils import read_block, tokenize
 
 # alternative names for some methods, which get patched to new instances
+# (alias, original)
 aliases = [
     ('makedir', 'mkdir'),
+    ('mkdirs', 'makedirs'),
     ('listdir', 'ls'),
     ('cp', 'copy'),
     ('move', 'mv'),
@@ -385,7 +387,7 @@ class AbstractFileSystem(object):
         allpaths = []
         for dirname, dirs, fils in self.walk(root, maxdepth=depth):
             allpaths.extend(posixpath.join(dirname, f) for f in fils)
-        pattern = re.compile("^" + path.replace('.', '\.')
+        pattern = re.compile("^" + path.replace('.', r'\.')
                              .replace('//', '/')
                              .rstrip('/')
                              .replace('*', '[^/]*')

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -425,8 +425,10 @@ class AbstractFileSystem(object):
         out1 = [o for o in out if o['name'].rstrip('/') == path]
         if len(out1) == 1:
             return out1[0]
-        else:
+        elif len(out1) > 1:
             return {'name': path, 'size': 0, 'type': 'directory'}
+        else:
+            raise FileNotFoundError
 
     def size(self, path):
         """Size in bytes of file"""

--- a/fsspec/spec.py
+++ b/fsspec/spec.py
@@ -297,7 +297,12 @@ class AbstractFileSystem(object):
         dirs = []
         files = []
 
-        for info in self.ls(path, True):
+        try:
+            listing = self.ls(path, True)
+        except FileNotFoundError:
+            return [], [], []
+
+        for info in listing:
             # each info name must be at least [path]/part , but here
             # we check also for names like [path]/part/
             name = info['name'].rstrip('/')


### PR DESCRIPTION
Note that FUSE always asks for paths starting with '/', so we strip this.
If you are mounting a real path, therefore, be sure to end it with '/' to
make the join work.

Use:

```python
import fsspec.fuse
fs = fsspec.filesystem('sftp', host='localhost')
fsspec.fuse.run(fs, '/Users/mdurant/temp/', '/Users/mdurant/mounting/')
```
(the destination must exist and be an empty directory)
Now the contents of the former directory are available in the latter location, for reading and writing.

This will not work for file implementations that do not support random access, and will have poor random-access performance for ones that only simulate random access with read-ahead (e.g., gcsfs, s3fs).