### PR TITLE
Close once

### DIFF
--- a/fsspec/implementations/cached.py
+++ b/fsspec/implementations/cached.py
@@ -756,6 +756,8 @@ class LocalTempFile:
         self.close()
 
     def close(self):
+        if self.closed:
+            return
         self.fh.close()
         self.closed = True
         if self.autocommit:


### PR DESCRIPTION
Should `LocalTempFile.discard` not also get the closed flag check?